### PR TITLE
Fix server scripts runtime error due to mixed import and require usage

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -14,12 +14,12 @@ const mongoose = require('mongoose');
 
 
 // SSR method importing from ./controller/ssr
-import { renderSSRcomponent } from "./controller/ssr";
+const { renderSSRcomponent } = require("./controller/ssr");
 
 
-import {
+const {
   MONGO_URL
-} from '../../config/index'
+} = require('../../config/index');
 
 
 console.log('MONGO_URl :', MONGO_URL);


### PR DESCRIPTION
The error arose when you run `npm run watch` which produces a fresh bin/server.js chunk containing mixed import and require syntax and then, run `npm run server:dev` which runs the `server.js` produced from last command.

Refer [this](https://github.com/webpack/webpack/issues/4039#issuecomment-273804003).

PS: I edited the `build` to `watch` in the above statement.