### PR TITLE
Incompatible Packages #169 fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,11 +52,10 @@
 		"react-router-dom": "^5.0.1"
 	},
 	"devDependencies": {
-		"@babel/core": "^7.5.5",
+		"@babel/core": "^7.22.10",
 		"@babel/plugin-syntax-dynamic-import": "^7.2.0",
 		"@babel/plugin-transform-runtime": "^7.4.3",
 		"@babel/preset-env": "^7.4.4",
-		"@babel/preset-es2015": "^7.0.0-beta.53",
 		"@babel/preset-react": "^7.0.0",
 		"@lhci/cli": "^0.3.4",
 		"babel-eslint": "^10.0.2",


### PR DESCRIPTION
I have successfully resolved the issue, that occurred while running "npm install" in the terminal on your project. The issue persisted due to the use of "babel-preset-es2015". This package got deprecated by Babel and according to them we should use "babel-preset-env". So I removed the deprecated package and used the latest "babel-preset-env" package. I also needed to update the @babel/core": "^7.5.5" package to the latest "7.22.10" version.